### PR TITLE
Excluding non-enumerable symbol-named object properties from cloning

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -24,6 +24,13 @@ try {
   nativePromise = function() {};
 }
 
+var nativeSymbol;
+try {
+  nativeSymbol = Symbol;
+} catch(_) {
+  nativeSymbol = function() {};
+}
+
 /**
  * Clones (copies) an Object using deep copying.
  *
@@ -164,6 +171,10 @@ function clone(parent, circular, depth, prototype) {
         // Don't need to worry about cloning a symbol because it is a primitive,
         // like a number or string.
         var symbol = symbols[i];
+        var descriptor = Object.getOwnPropertyDescriptor(parent, symbol);
+        if (descriptor && !descriptor.enumerable) {
+          continue;
+        }
         child[symbol] = _clone(parent[symbol], depth - 1);
       }
     }

--- a/clone.js
+++ b/clone.js
@@ -24,13 +24,6 @@ try {
   nativePromise = function() {};
 }
 
-var nativeSymbol;
-try {
-  nativeSymbol = Symbol;
-} catch(_) {
-  nativeSymbol = function() {};
-}
-
 /**
  * Clones (copies) an Object using deep copying.
  *

--- a/test.js
+++ b/test.js
@@ -512,3 +512,31 @@ if (nativePromise) {
     });
   }
 }
+
+var nativeSymbol;
+try {
+  nativeSymbol = Symbol
+} catch(_) {}
+if (nativeSymbol) {
+  exports["clone only enumerable symbol properties"] = function (test) {
+    test.expect(3);
+
+    var source = {};
+    var symbol1 = nativeSymbol('the first symbol');
+    var symbol2 = nativeSymbol('the second symbol');
+    var symbol3 = nativeSymbol('the third symbol');
+    source[symbol1] = 1;
+    source[symbol2] = 2;
+    source[symbol3] = 3;
+    Object.defineProperty(source, symbol2, {
+      enumerable: false
+    });
+
+    var cloned = clone(source);
+    test.equal(cloned[symbol1], 1);
+    test.equal(cloned.hasOwnProperty(symbol2), false);
+    test.equal(cloned[symbol3], 3);
+
+    test.done();
+  };
+}


### PR DESCRIPTION
The non-enumerable string-named object properties were already excluded (the for-in skips non-enumerable properties). This ensures the same consistent behavior for symbols.

Please publish this as soon as possible. Thank you in advance.